### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ MainStore.getContributorsForField("login", "fabianterhorst", new Chest.ReadCallb
 });
 ```
 
-####RxJava support
+#### RxJava support
 
 Set a value asynchron with RxJava
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
